### PR TITLE
Seth TPAGBwind runstar

### DIFF
--- a/r11701/default_common_inlists/binary/inlist1
+++ b/r11701/default_common_inlists/binary/inlist1
@@ -254,6 +254,8 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(3) = .true.
       ! for the simplified accretion model, which will stop accretion and wind loss for the rapid rotating accretor
       x_logical_ctrl(4) = .false.
+      ! skip calculating implicit mdot
+      x_logical_ctrl(5) = .true.
 
 
 / ! end of controls namelist

--- a/r11701/default_common_inlists/binary/inlist2
+++ b/r11701/default_common_inlists/binary/inlist2
@@ -250,4 +250,6 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(3) = .true.
       ! for the simplified accretion model, which will stop accretion and wind loss for the rapid rotating accretor
       x_logical_ctrl(4) = .false.
+      ! skip calculating implicit mdot
+      x_logical_ctrl(5) = .true.
  / ! end of controls namelist

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -882,7 +882,7 @@ contains
     end if
 
     ! TP-AGB
-    if(TP_AGB_check .and. s% have_done_TP)then
+    if (TP_AGB_check .and. (s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
        TP_AGB_check = .false.
        late_AGB_check = .true.
        write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
@@ -1014,12 +1014,12 @@ contains
     end if
 
     ! TP-AGB
-    if(s% have_done_TP) then
+    !if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
        !termination_code_str(t_xtra2) = 'Reached TPAGB'
        !s% termination_code = t_xtra2
        !extras_finish_step = terminate
-       write(*,'(g0)') 'Reached TPAGB'
-    end if
+    !   write(*,'(g0)') 'Reached TPAGB'
+    !end if
   end function extras_finish_step
 
 
@@ -1469,7 +1469,7 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
        if(T1 <= s% hot_wind_full_on_T)then
           !evaluate cool wind
           !RGB/TPAGB switch goes here
-          if (s% have_done_TP) then
+          if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
              scheme = s% cool_wind_AGB_scheme
              if (dbg) &
                   write(*,1) 'using cool_wind_AGB_scheme: "' // trim(scheme) // '"', &

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -1461,52 +1461,53 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
 
     !massive stars
     !if(s% initial_mass >= 10._dp)then
-    if (T1 > s% hot_wind_full_on_T) then
-       scheme = s% hot_wind_scheme
-       call eval_wind_for_scheme(scheme,wind)
-       if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
+    !if (T1 > s% hot_wind_full_on_T) then
+    !   scheme = s% hot_wind_scheme
+    !   call eval_wind_for_scheme(scheme,wind)
+    !   if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
     !low-mass stars
-    else if(T1 <= s% hot_wind_full_on_T)then
-          !evaluate cool wind
-          !RGB/TPAGB switch goes here
-          if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
-             scheme = s% cool_wind_AGB_scheme
-             if (dbg) &
-                  write(*,1) 'using cool_wind_AGB_scheme: "' // trim(scheme) // '"', &
-                  center_h1, center_he4, s% RGB_to_AGB_wind_switch
-
-          else
-             scheme= s% cool_wind_RGB_scheme
-             if (dbg) write(*,*) 'using cool_wind_RGB_scheme: "' // trim(scheme) // '"'
-
-          endif
-          call eval_wind_for_scheme(scheme, cool_wind)
-       endif
-
-       if(T1 >= s% cool_wind_full_on_T)then
-          !evaluate hot wind
-          scheme="Dutch"
-          call eval_wind_for_scheme(scheme, hot_wind)
-          if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
-
-       endif
-
-       !now we have both hot and cool wind
-
-       if(T1 < s% cool_wind_full_on_T) then
-          wind = cool_wind
-
-       elseif(T1 > s% hot_wind_full_on_T) then
-          wind = hot_wind
+    !else 
+    if(T1 <= s% hot_wind_full_on_T)then
+       !evaluate cool wind
+       !RGB/TPAGB switch goes here
+       if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
+          scheme = s% cool_wind_AGB_scheme
+          if (dbg) &
+            write(*,1) 'using cool_wind_AGB_scheme: "' // trim(scheme) // '"', &
+            center_h1, center_he4, s% RGB_to_AGB_wind_switch
 
        else
-          !now combine the contributions of hot and cool winds
-          divisor = s% hot_wind_full_on_T - s% cool_wind_full_on_T
-          beta = min( (s% hot_wind_full_on_T - T1) / divisor, 1d0)
-          alfa = 1d0 - beta
-          wind = alfa*hot_wind + beta*cool_wind
+          scheme= s% cool_wind_RGB_scheme
+          if (dbg) write(*,*) 'using cool_wind_RGB_scheme: "' // trim(scheme) // '"'
+
        endif
+       call eval_wind_for_scheme(scheme, cool_wind)
     endif
+
+    if(T1 >= s% cool_wind_full_on_T)then
+       !evaluate hot wind
+       scheme="Dutch"
+       call eval_wind_for_scheme(scheme, hot_wind)
+       if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
+
+    endif
+
+    !now we have both hot and cool wind
+
+    if(T1 < s% cool_wind_full_on_T) then
+       wind = cool_wind
+
+    elseif(T1 > s% hot_wind_full_on_T) then
+       wind = hot_wind
+
+    else
+       !now combine the contributions of hot and cool winds
+       divisor = s% hot_wind_full_on_T - s% cool_wind_full_on_T
+       beta = min( (s% hot_wind_full_on_T - T1) / divisor, 1d0)
+       alfa = 1d0 - beta
+       wind = alfa*hot_wind + beta*cool_wind
+    endif
+   !endif
 
   contains
 

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -1466,8 +1466,7 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
        call eval_wind_for_scheme(scheme,wind)
        if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
     !low-mass stars
-    else
-       if(T1 <= s% hot_wind_full_on_T)then
+    else if(T1 <= s% hot_wind_full_on_T)then
           !evaluate cool wind
           !RGB/TPAGB switch goes here
           if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
@@ -1513,7 +1512,8 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
 
     subroutine eval_wind_for_scheme(scheme,wind)
       character(len=strlen) :: scheme
-      real(dp), intent(out) :: wind, reimers_wind
+      real(dp), intent(out) :: wind
+      real(dp) :: reimers_wind
       include 'formats'
 
       current_wind_prscr = 0d0

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -895,7 +895,7 @@ contains
        s% delta_lgTeff_hard_limit = -1d0
        s% delta_lgL_limit = -1d0
        s% delta_lgL_hard_limit = -1d0
-       s% Blocker_scaling_factor = 2.0d0
+       !s% Blocker_scaling_factor = 2.0d0 ! deprecated?
        !s% varcontrol_target = 2.0d0*s% varcontrol_target
        write(*,*) ' varcontrol_target = ', s% varcontrol_target
        write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
@@ -910,7 +910,7 @@ contains
           write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
           write(*,*) 'now at late AGB phase, model number ', s% model_number
           write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
-          s% Blocker_scaling_factor = 5.0d0
+          !s% Blocker_scaling_factor = 5.0d0 ! deprecated?
           late_AGB_check=.false.
           post_AGB_check=.true.
        endif
@@ -945,7 +945,7 @@ contains
     if(pre_WD_check)then
        if(s% Teff < 3.0d4 .and. s% L_surf < 1.0d0)then
           pre_WD_check = .false.
-          s% do_Ne22_sedimentation_heating = .true.
+          !s% do_Ne22_sedimentation_heating = .true. ! Ne22 is not in the current net, so this causes a crash
           write(*,*) '++++++++++++++++++++++++++++++++++++++++++++++'
           write(*,*) 'now at WD phase, model number ', s% model_number
           !if(s% job% extras_lpar(2))then
@@ -1013,7 +1013,7 @@ contains
        s% diffusion_dt_limit = original_diffusion_dt_limit
     end if
 
-    ! TP-AGB
+    ! TP-AGB ! deprecated?
     !if ((s% he_core_mass - s% c_core_mass < 1d-1) .and. (s% center_he4 < 1d-6)) then
        !termination_code_str(t_xtra2) = 'Reached TPAGB'
        !s% termination_code = t_xtra2
@@ -1460,7 +1460,8 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
     end if
 
     !massive stars
-    if(s% initial_mass >= 10._dp)then
+    !if(s% initial_mass >= 10._dp)then
+    if (T1 > s% hot_wind_full_on_T) then
        scheme = s% hot_wind_scheme
        call eval_wind_for_scheme(scheme,wind)
        if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'


### PR DESCRIPTION
This PR introduces new logic to how MESA decides whether or not to use a TP-AGB wind (Blocker 1995). Previously, it used the condition `s% have_done_TP` which never triggers if convective shell overshooting is 0 (which it is in our inlists).

The new logic checks that the star has a He depleted core and that the He shell mass is < 0.1 Msol. The TP-AGB phase is post-He burning, and occurs via unstable He ignition in a thin He shell above the CO core. This logic is meant to identify physical conditions where this should occur, and turn the TP-AGB wind on when they are satisfied.

Additionally, the maximum of either the Reimers (RGB) or Blocker (TP-AGB) wind is used. The wind transitions from Reimers to Blocker as a low mass star evolves, and Blocker overtakes Reimers during thermal pulses.

Previously there was a condition which said that as long as the model's initial mass was greater than 10 solar masses, the star should experience high mass "Dutch" winds. This would mean that any star that may have lost mass and become "low mass" ( < 10 Msol in this case) would still have the "Dutch" wind applied. This condition has been removed. The logic now checks instead whether a star satisfies the condition 

```
if (T1 > s% hot_wind_full_on_T) then
       ! assign Dutch wind
       ...
```
where `s% hot_wind_full_on_T` is set in the inlists as T = 12000 K.

The changes exist in `run_star_extras.f`.

TO DO: test that the max(Reimers, Blocker) transition works properly.