### PR TITLE
magnetic braking only for RLOFing HMS stars

### DIFF
--- a/r11701/CO-He_star/binary/inlist1
+++ b/r11701/CO-He_star/binary/inlist1
@@ -7,6 +7,6 @@
 &controls
      x_ctrl(1) = 1.0d0 ! Eddinton limit
 
-     ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
+     ! Allow for magnetic breaking to be turned on, when the star fills its Roche lobe. If true, in run_binary_extras, do_jdot_mb will be set to .true. when the star fills its Roche lobe. If .false. then magnetic breaking is never turned on.
      x_logical_ctrl(6) = .false.
 / ! end of controls namelist

--- a/r11701/CO-He_star/binary/inlist1
+++ b/r11701/CO-He_star/binary/inlist1
@@ -7,6 +7,7 @@
 &controls
      x_ctrl(1) = 1.0d0 ! Eddinton limit
 
-     ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
-     x_logical_ctrl(6) = .false.
+     ! if true, avoid implementing magnetic braking for this star at RLO (do_jdot_mb stays .false.). in run_binary_extras
+     ! We have the option this not implement it for He_Stars in the CO-He_star grid
+     x_logical_ctrl(6) = .true.
 / ! end of controls namelist

--- a/r11701/CO-He_star/binary/inlist1
+++ b/r11701/CO-He_star/binary/inlist1
@@ -6,4 +6,7 @@
 
 &controls
      x_ctrl(1) = 1.0d0 ! Eddinton limit
+
+     ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
+     x_logical_ctrl(6) = .false.
 / ! end of controls namelist

--- a/r11701/CO-He_star/binary/inlist1
+++ b/r11701/CO-He_star/binary/inlist1
@@ -7,6 +7,6 @@
 &controls
      x_ctrl(1) = 1.0d0 ! Eddinton limit
 
-     ! Allow for magnetic breaking to be turned on, when the star fills its Roche lobe. If true, in run_binary_extras, do_jdot_mb will be set to .true. when the star fills its Roche lobe. If .false. then magnetic breaking is never turned on.
+     ! Allow for magnetic breaking to be turned on, when the star fills its Roche lobe. If true, in run_binary_extras, do_jdot_mb will be set to .true. when the star fills its Roche lobe. If .false. then magnetic breaking is never turned on. For He stars, we do not apply magnetic breaking.
      x_logical_ctrl(6) = .false.
 / ! end of controls namelist

--- a/r11701/default_common_inlists/binary/inlist1
+++ b/r11701/default_common_inlists/binary/inlist1
@@ -256,8 +256,9 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(4) = .false.
       ! skip calculating implicit mdot
       x_logical_ctrl(5) = .true.
-      ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
-      x_logical_ctrl(6) = .true.
+      ! if true, avoid implementing magnetic braking for this star at RLO (do_jdot_mb stays .false.). in run_binary_extras
+      ! We have the option this not implement it for He_Stars in the CO-He_star grid
+      x_logical_ctrl(6) = .false.
 
 
 / ! end of controls namelist

--- a/r11701/default_common_inlists/binary/inlist1
+++ b/r11701/default_common_inlists/binary/inlist1
@@ -256,7 +256,7 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(4) = .false.
       ! skip calculating implicit mdot
       x_logical_ctrl(5) = .true.
-      ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
+      ! Allow for magnetic breaking to be turned on, when the star fills its Roche lobe. If true, in run_binary_extras, do_jdot_mb will be set to .true. when the star fills its Roche lobe. If .false. then magnetic breaking is never turned on.
       x_logical_ctrl(6) = .true.
 
 

--- a/r11701/default_common_inlists/binary/inlist1
+++ b/r11701/default_common_inlists/binary/inlist1
@@ -256,6 +256,8 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(4) = .false.
       ! skip calculating implicit mdot
       x_logical_ctrl(5) = .true.
+      ! implement magnetic braking for this star (do_jdot_mb=.true.). We have the option to not implement it for He_Stars in the CO-He_star grid
+      x_logical_ctrl(6) = .true.
 
 
 / ! end of controls namelist

--- a/r11701/default_common_inlists/binary/src/run_binary_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_binary_extras.f
@@ -1184,7 +1184,7 @@
            b% s_donor => b% s2
          end if
           ! Turning back on binary orbital evolution
-          if (b% s_donor% x_logical_ctrl(6)) then
+          if (.not. b% s_donor% x_logical_ctrl(6)) then
               b% do_jdot_mb = .true. ! turn on magnetic braking for RLOFing HMS stars only
           end if
           b% do_jdot_gr = .true.

--- a/r11701/default_common_inlists/binary/src/run_binary_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_binary_extras.f
@@ -1178,11 +1178,15 @@
          .or. (abs(b% mtransfer_rate/(Msun/secyer)) .ge. 1.0d-10))) then
          if (b% point_mass_i/=1) then
            i_don = 1
+           b% s_donor => b% s1
          else
            i_don = 2
+           b% s_donor => b% s2
          end if
-          ! Binary evolution
-          b% do_jdot_mb = .true.
+          ! Turning back on binary orbital evolution
+          if (b% s_donor% x_logical_ctrl(6)) then
+              b% do_jdot_mb = .true. ! turn on magnetic braking for RLOFing HMS stars only
+          end if
           b% do_jdot_gr = .true.
           b% do_jdot_ml = .true.
           b% do_jdot_ls = .true.

--- a/r11701/default_common_inlists/binary/src/run_binary_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_binary_extras.f
@@ -1185,7 +1185,7 @@
          end if
           ! Turning back on binary orbital evolution
           if (b% s_donor% x_logical_ctrl(6)) then
-              b% do_jdot_mb = .true. ! turn on magnetic braking for RLOFing HMS stars only
+              b% do_jdot_mb = .true. ! turn on magnetic braking for RLOFing stars
           end if
           b% do_jdot_gr = .true.
           b% do_jdot_ml = .true.

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -163,7 +163,7 @@ contains
       call star_ptr(id,s,ierr)
       if(ierr/=0) return
       !here is an example for adding an extra history header item
-      !set num_cols=1 in how_many_extra_history_header_items and then unccomment these lines
+      !set num_cols=1 in how_many_extra_history_header_items and then uncomment these lines
       initial_X = 0._dp
       initial_Y = 0._dp
       initial_Z = 0._dp
@@ -1466,7 +1466,7 @@ subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy
     !   call eval_wind_for_scheme(scheme,wind)
     !   if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
     !low-mass stars
-    !else 
+    !else
     if(T1 <= s% hot_wind_full_on_T)then
        !evaluate cool wind
        !RGB/TPAGB switch goes here


### PR DESCRIPTION
Added x_logical_ctrl(6) in default inlist1 which allows to turn on magnetic braking for point masses during RLOF, only when it is .true.
In the inlilist 1 of CO-He_star, it is .false.