### PR TITLE
less lambda error outputs

### DIFF
--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -483,9 +483,11 @@ contains
                            - diss_energy_H2
 
        if (adjusted_energy(k) < 0d0 .or. adjusted_energy(k) > s% energy(k)) then
-          write(*,*) "Error when computing adjusted energy in CE, ", &
-             "s% energy(k):", s% energy(k), " adjusted_energy, ", adjusted_energy(k)
-             sticking_to_energy_without_recombination_corr = .true.
+          if (.not. sticking_to_energy_without_recombination_corr) then
+             write(*,*) "Error when computing adjusted energy in CE, ", &
+                "s% energy(k):", s% energy(k), " adjusted_energy, ", adjusted_energy(k)
+          end if
+          sticking_to_energy_without_recombination_corr = .true.
        end if
 
       if(.false.) then


### PR DESCRIPTION
This PR addresses [issue#22](https://github.com/POSYDON-code/POSYDON-MESA-INLISTS/issues/22)
- [x] write energy error only once per model instead of every shell