### PR TITLE
Matthias fix initial hestar

### DIFF
--- a/r11701/CO-He_star/star1_formation/src/run_star_extras.f
+++ b/r11701/CO-He_star/star1_formation/src/run_star_extras.f
@@ -886,8 +886,8 @@ contains
     call store_extra_info(s)
 
     ! consistent with H-ZAMS definition from Aaron
-    if (((s% power_he_burn + s% power_z_burn) * Lsun / s% L(1) > 0.985) .and. &
-        (s% power_he_burn > s% power_z_burn))  extras_finish_step = terminate
+    if ((s% power_nuc_burn * Lsun / s% L(1) > 0.985) .and. &
+        (s% power_he_burn > 0.5*s% power_nuc_burn))  extras_finish_step = terminate
     if (extras_finish_step == terminate) s% termination_code =t_extras_finish_step
 
 

--- a/r11701/CO-He_star/star1_formation/src/run_star_extras.f
+++ b/r11701/CO-He_star/star1_formation/src/run_star_extras.f
@@ -886,7 +886,8 @@ contains
     call store_extra_info(s)
 
     ! consistent with H-ZAMS definition from Aaron
-    if (s% power_he_burn * Lsun / s% L(1) > 0.985)  extras_finish_step = terminate
+    if (((s% power_he_burn + s% power_z_burn) * Lsun / s% L(1) > 0.985) .and. &
+        (s% power_he_burn > s% power_z_burn))  extras_finish_step = terminate
     if (extras_finish_step == terminate) s% termination_code =t_extras_finish_step
 
 

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -879,8 +879,8 @@ contains
     call store_extra_info(s)
     if(s% x_logical_ctrl(2)) then ! this should only up for the 2 step of He star formation
       ! consistent with H-ZAMS definition from Aaron
-      if (((s% power_he_burn + s% power_z_burn) * Lsun / s% L(1) > 0.985) .and. &
-          (s% power_he_burn > s% power_z_burn))  extras_finish_step = terminate
+      if ((s% power_nuc_burn * Lsun / s% L(1) > 0.985) .and. &
+          (s% power_he_burn > 0.5*s% power_nuc_burn))  extras_finish_step = terminate
       if (extras_finish_step == terminate) s% termination_code =t_extras_finish_step
     end if
 

--- a/r11701/default_common_inlists/binary/src/run_star_extras.f
+++ b/r11701/default_common_inlists/binary/src/run_star_extras.f
@@ -879,7 +879,8 @@ contains
     call store_extra_info(s)
     if(s% x_logical_ctrl(2)) then ! this should only up for the 2 step of He star formation
       ! consistent with H-ZAMS definition from Aaron
-      if (s% power_he_burn * Lsun / s% L(1) > 0.985)  extras_finish_step = terminate
+      if (((s% power_he_burn + s% power_z_burn) * Lsun / s% L(1) > 0.985) .and. &
+          (s% power_he_burn > s% power_z_burn))  extras_finish_step = terminate
       if (extras_finish_step == terminate) s% termination_code =t_extras_finish_step
     end if
 


### PR DESCRIPTION
- [x] Add Z-burning power in luminosity comparison and request He burning to dominate.
- [x] testing:

system | initial Y_c (old) | initial Y_c (new) | delta age on pre MS evolution
-|-|-|-
`m1_1.6992_m2_39.2720_initial_z_2.8400e-02_initial_period_in_days_5.9023e+01` | 0.000000 | 0.967814 | 4 915 153 yr
`m1_1.2608_m2_12.1697_initial_z_2.8400e-02_initial_period_in_days_1.0757e+01` | 0.967467 | 0.968097 | 4 880 yr
`m1_2.5681_m2_5.6963_initial_z_2.8400e-02_initial_period_in_days_6.9597e+00` | 0.934794 | 0.967657 | 70 325 yr
`m1_1.3150_m2_1.6219_initial_z_2.8400e-02_initial_period_in_days_1.3753e+01` | 0.967178 | 0.967928 | 5 296 yr